### PR TITLE
fix log_path

### DIFF
--- a/diverserl/common/utils.py
+++ b/diverserl/common/utils.py
@@ -1,6 +1,7 @@
 import random
 import re
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import gymnasium as gym
@@ -10,6 +11,10 @@ from gymnasium import Env
 from gymnasium.wrappers import (AtariPreprocessing, FlattenObservation,
                                 FrameStack)
 from torch import nn
+
+
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent.parent #./DiverseRL
 
 
 def soft_update(network: nn.Module, target_network: nn.Module, tau: float) -> None:

--- a/diverserl/trainers/base.py
+++ b/diverserl/trainers/base.py
@@ -10,11 +10,10 @@ from gymnasium.wrappers import RecordVideo
 from rich.console import Console
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
 
-from diverserl.common.utils import env_namespace
+from diverserl.common.utils import env_namespace, get_project_root
 
-ROOT_PATH = sys.path[1]
+ROOT_PATH = get_project_root() #./DiverseRL
 LOG_PATH = f"{ROOT_PATH}/logs"
-WANDB_PATH = f"{ROOT_PATH}/wandb"  # Wandb in LOG_PATH causes error.
 
 
 class Trainer(ABC):


### PR DESCRIPTION
- problem in `ROOT_PATH` of `Trainers/base.py` 
-`ROOT_PATH` = '/Users/.pyenv/versions/3.10.13/lib/python310.zip' in terminal

-solution: https://stackoverflow.com/questions/25389095/python-get-path-of-root-project-structure
```
from pathlib import Path

def get_project_root() -> Path:
    return Path(__file__).parent.parent
```

in common/utils
